### PR TITLE
VS2019でのビルドをサポート（第3章から16章まで）

### DIFF
--- a/Chapter10/Chapter10.vcxproj
+++ b/Chapter10/Chapter10.vcxproj
@@ -89,7 +89,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <FxCompile>
       <EntryPointName />

--- a/Chapter10/Dx12Wrapper.cpp
+++ b/Chapter10/Dx12Wrapper.cpp
@@ -221,7 +221,7 @@ Dx12Wrapper::GetTextureByPath(const char* texpath) {
 void 
 Dx12Wrapper::CreateTextureLoaderTable() {
 	_loadLambdaTable["sph"] = _loadLambdaTable["spa"] = _loadLambdaTable["bmp"] = _loadLambdaTable["png"] = _loadLambdaTable["jpg"] = [](const wstring& path, TexMetadata* meta, ScratchImage& img)->HRESULT {
-		return LoadFromWICFile(path.c_str(), 0, meta, img);
+		return LoadFromWICFile(path.c_str(), WIC_FLAGS_NONE, meta, img);
 	};
 
 	_loadLambdaTable["tga"] = [](const wstring& path, TexMetadata* meta, ScratchImage& img)->HRESULT {
@@ -229,7 +229,7 @@ Dx12Wrapper::CreateTextureLoaderTable() {
 	};
 
 	_loadLambdaTable["dds"] = [](const wstring& path, TexMetadata* meta, ScratchImage& img)->HRESULT {
-		return LoadFromDDSFile(path.c_str(), 0, meta, img);
+		return LoadFromDDSFile(path.c_str(), DDS_FLAGS_NONE, meta, img);
 	};
 }
 //テクスチャ名からテクスチャバッファ作成、中身をコピー
@@ -384,11 +384,13 @@ Dx12Wrapper::CreateSceneView(){
 	DXGI_SWAP_CHAIN_DESC1 desc = {};
 	auto result = _swapchain->GetDesc1(&desc);
 
+	auto heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	auto resDesc = CD3DX12_RESOURCE_DESC::Buffer((sizeof(SceneData) + 0xff) & ~0xff);
 	//定数バッファ作成
 	result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer((sizeof(SceneData) + 0xff)&~0xff),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(_sceneConstBuff.ReleaseAndGetAddressOf())
@@ -490,11 +492,10 @@ Dx12Wrapper::BeginDraw() {
 	//DirectX処理
 	//バックバッファのインデックスを取得
 	auto bbIdx = _swapchain->GetCurrentBackBufferIndex();
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
+		D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-	_cmdList->ResourceBarrier(1,
-		&CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
-			D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
-
+	_cmdList->ResourceBarrier(1, &barrier);
 
 	//レンダーターゲットを指定
 	auto rtvH = _rtvHeaps->GetCPUDescriptorHandleForHeapStart();
@@ -529,12 +530,9 @@ Dx12Wrapper::SetScene() {
 void
 Dx12Wrapper::EndDraw() {
 	auto bbIdx = _swapchain->GetCurrentBackBufferIndex();
-	_cmdList->ResourceBarrier(1,
-		&CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
-			D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
-
-
-
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
+		D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
+	_cmdList->ResourceBarrier(1, &barrier);
 
 	ExecuteCommand();
 }

--- a/Chapter10/Dx12Wrapper.h
+++ b/Chapter10/Dx12Wrapper.h
@@ -6,6 +6,7 @@
 #include<wrl.h>
 #include<string>
 #include<functional>
+#include<memory>
 
 class Dx12Wrapper
 {

--- a/Chapter10/PMDActor.h
+++ b/Chapter10/PMDActor.h
@@ -90,7 +90,7 @@ private:
 
 	//PMDファイルのロード
 	HRESULT LoadPMDFile(const char* path);
-	void RecursiveMatrixMultipy(BoneNode* node, DirectX::XMMATRIX& mat);
+	void RecursiveMatrixMultipy(BoneNode* node, const DirectX::XMMATRIX& mat);
 	float _angle;//テスト用Y軸回転
 
 
@@ -99,11 +99,15 @@ private:
 		unsigned int frameNo;//フレーム№(アニメーション開始からの経過時間)
 		DirectX::XMVECTOR quaternion;//クォータニオン
 		DirectX::XMFLOAT2 p1, p2;//ベジェの中間コントロールポイント
-		KeyFrame(unsigned int fno, DirectX::XMVECTOR& q,const DirectX::XMFLOAT2& ip1,const DirectX::XMFLOAT2& ip2):
+		KeyFrame(
+			unsigned int fno,
+			const DirectX::XMVECTOR& q,
+			const DirectX::XMFLOAT2& ip1,
+			const DirectX::XMFLOAT2& ip2) :
 			frameNo(fno),
 			quaternion(q),
 			p1(ip1),
-			p2(ip2){}
+			p2(ip2) {}
 	};
 	std::unordered_map<std::string, std::vector<KeyFrame>> _motiondata;
 

--- a/Chapter11/Chapter11.vcxproj
+++ b/Chapter11/Chapter11.vcxproj
@@ -89,7 +89,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <FxCompile>
       <EntryPointName />

--- a/Chapter11/Dx12Wrapper.cpp
+++ b/Chapter11/Dx12Wrapper.cpp
@@ -221,7 +221,7 @@ Dx12Wrapper::GetTextureByPath(const char* texpath) {
 void 
 Dx12Wrapper::CreateTextureLoaderTable() {
 	_loadLambdaTable["sph"] = _loadLambdaTable["spa"] = _loadLambdaTable["bmp"] = _loadLambdaTable["png"] = _loadLambdaTable["jpg"] = [](const wstring& path, TexMetadata* meta, ScratchImage& img)->HRESULT {
-		return LoadFromWICFile(path.c_str(), 0, meta, img);
+		return LoadFromWICFile(path.c_str(), WIC_FLAGS_NONE, meta, img);
 	};
 
 	_loadLambdaTable["tga"] = [](const wstring& path, TexMetadata* meta, ScratchImage& img)->HRESULT {
@@ -229,7 +229,7 @@ Dx12Wrapper::CreateTextureLoaderTable() {
 	};
 
 	_loadLambdaTable["dds"] = [](const wstring& path, TexMetadata* meta, ScratchImage& img)->HRESULT {
-		return LoadFromDDSFile(path.c_str(), 0, meta, img);
+		return LoadFromDDSFile(path.c_str(), DDS_FLAGS_NONE, meta, img);
 	};
 }
 //テクスチャ名からテクスチャバッファ作成、中身をコピー
@@ -384,11 +384,13 @@ Dx12Wrapper::CreateSceneView(){
 	DXGI_SWAP_CHAIN_DESC1 desc = {};
 	auto result = _swapchain->GetDesc1(&desc);
 
+	auto heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	auto resDesc = CD3DX12_RESOURCE_DESC::Buffer((sizeof(SceneData) + 0xff) & ~0xff);
 	//定数バッファ作成
 	result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer((sizeof(SceneData) + 0xff)&~0xff),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(_sceneConstBuff.ReleaseAndGetAddressOf())
@@ -490,11 +492,10 @@ Dx12Wrapper::BeginDraw() {
 	//DirectX処理
 	//バックバッファのインデックスを取得
 	auto bbIdx = _swapchain->GetCurrentBackBufferIndex();
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
+		D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-	_cmdList->ResourceBarrier(1,
-		&CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
-			D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
-
+	_cmdList->ResourceBarrier(1, &barrier);
 
 	//レンダーターゲットを指定
 	auto rtvH = _rtvHeaps->GetCPUDescriptorHandleForHeapStart();
@@ -529,12 +530,10 @@ Dx12Wrapper::SetScene() {
 void
 Dx12Wrapper::EndDraw() {
 	auto bbIdx = _swapchain->GetCurrentBackBufferIndex();
-	_cmdList->ResourceBarrier(1,
-		&CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
-			D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_backBuffers[bbIdx],
+		D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
 
-
-
+	_cmdList->ResourceBarrier(1, &barrier);
 
 	ExecuteCommand();
 }

--- a/Chapter11/Dx12Wrapper.h
+++ b/Chapter11/Dx12Wrapper.h
@@ -6,6 +6,8 @@
 #include<wrl.h>
 #include<string>
 #include<functional>
+#include<memory>
+#include<algorithm>
 
 class Dx12Wrapper
 {

--- a/Chapter11/PMDActor.h
+++ b/Chapter11/PMDActor.h
@@ -116,7 +116,12 @@ private:
 		DirectX::XMVECTOR quaternion;//クォータニオン
 		DirectX::XMFLOAT3 offset;//IKの初期座標からのオフセット情報
 		DirectX::XMFLOAT2 p1, p2;//ベジェの中間コントロールポイント
-		KeyFrame(unsigned int fno, DirectX::XMVECTOR& q,DirectX::XMFLOAT3& ofst, DirectX::XMFLOAT2& ip1,const DirectX::XMFLOAT2& ip2):
+		KeyFrame(
+			unsigned int fno, 
+			const DirectX::XMVECTOR& q,
+			const DirectX::XMFLOAT3& ofst,
+			const DirectX::XMFLOAT2& ip1,
+			const DirectX::XMFLOAT2& ip2):
 			frameNo(fno),
 			quaternion(q),
 			offset(ofst),

--- a/Chapter12/Chapter12.vcxproj
+++ b/Chapter12/Chapter12.vcxproj
@@ -89,7 +89,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -115,11 +115,14 @@
       <SDLCheck>false</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SupportJustMyCode>false</SupportJustMyCode>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <FxCompile>
       <EntryPointName />
@@ -159,7 +162,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter12/Dx12Wrapper.cpp
+++ b/Chapter12/Dx12Wrapper.cpp
@@ -179,10 +179,12 @@ Dx12Wrapper::CreatePeraVertex() {
 						{{-1,1,0.1},{0,0}},
 						{{1,-1,0.1},{1,1}},
 						{{1,1,0.1},{1,0}} };
+	auto heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	auto resDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(pv));
 	auto result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(pv)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(_peraVB.ReleaseAndGetAddressOf()));
@@ -278,17 +280,18 @@ Dx12Wrapper::CreateCommandList() {
 
 void 
 Dx12Wrapper::PostDrawToPera1() {
-	_cmdList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(_peraResource.Get(),
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_peraResource.Get(),
 		D3D12_RESOURCE_STATE_RENDER_TARGET,
-		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE));
+		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+	_cmdList->ResourceBarrier(1, &barrier);
 }
 
 bool 
 Dx12Wrapper::PreDrawToPera1() {
-	_cmdList->ResourceBarrier(1, 
-		&CD3DX12_RESOURCE_BARRIER::Transition(_peraResource.Get(),
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(_peraResource.Get(),
 		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-		D3D12_RESOURCE_STATE_RENDER_TARGET));
+		D3D12_RESOURCE_STATE_RENDER_TARGET);
+	_cmdList->ResourceBarrier(1, &barrier);
 	auto rtvHeapPointer = _peraRTVHeap->GetCPUDescriptorHandleForHeapStart();
 	auto dsvHeapPointer = _dsvHeap->GetCPUDescriptorHandleForHeapStart();
 	_cmdList->OMSetRenderTargets(1, &rtvHeapPointer, false, &dsvHeapPointer);
@@ -328,7 +331,8 @@ Dx12Wrapper::Clear() {
 void Dx12Wrapper::Barrier(ID3D12Resource* p,
 	D3D12_RESOURCE_STATES before,
 	D3D12_RESOURCE_STATES after){
-	_cmdList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(p, before, after, 0));
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(p, before, after, 0);
+	_cmdList->ResourceBarrier(1, &barrier);
 }
 
 void 
@@ -843,10 +847,12 @@ Dx12Wrapper::GetCameraPosition() {
 bool
 Dx12Wrapper::CreateBokehParamResource() {
 	auto weights=GetGaussianWeights(8, 5.0f);
+	auto heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	auto resDesc = CD3DX12_RESOURCE_DESC::Buffer(AligmentedValue(sizeof(weights[0]) * weights.size(), D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT));
 	auto result=_dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(AligmentedValue(sizeof(weights[0])*weights.size(),D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(_bokehParamResource.ReleaseAndGetAddressOf())
@@ -922,14 +928,14 @@ Dx12Wrapper::LoadPictureFromFile(wstring filepath, ComPtr<ID3D12Resource>& buff)
 			scratchImg);
 	}
 	else if (ext == L"dds") {
-		result = LoadFromDDSFile(filepath.c_str(),0,
+		result = LoadFromDDSFile(filepath.c_str(), DDS_FLAGS_NONE,
 			&metadata,
 			scratchImg);
 		isDXT = true;
 	}
 	else {
 		result = LoadFromWICFile(filepath.c_str(),
-			0,
+			WIC_FLAGS_NONE,
 			&metadata,
 			scratchImg);
 	}

--- a/Chapter12/Helper.h
+++ b/Chapter12/Helper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include<d3d12.h>
+#include<string>
 
 class Helper
 {

--- a/Chapter12/PMDActor.h
+++ b/Chapter12/PMDActor.h
@@ -8,6 +8,8 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
+#include<algorithm>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter13/Chapter13.vcxproj
+++ b/Chapter13/Chapter13.vcxproj
@@ -89,7 +89,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <FxCompile>
       <EntryPointName />
@@ -159,7 +159,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter13/Helper.h
+++ b/Chapter13/Helper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include<d3d12.h>
+#include<string>
 
 class Helper
 {

--- a/Chapter13/PMDActor.cpp
+++ b/Chapter13/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)

--- a/Chapter13/PMDActor.h
+++ b/Chapter13/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter13_shadowmap/Chapter13_shadowmap.vcxproj
+++ b/Chapter13_shadowmap/Chapter13_shadowmap.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -158,7 +158,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter13_shadowmap/Helper.h
+++ b/Chapter13_shadowmap/Helper.h
@@ -2,6 +2,7 @@
 
 #include<d3d12.h>
 #include<vector>
+#include<string>
 
 class Helper
 {

--- a/Chapter13_shadowmap/PMDActor.cpp
+++ b/Chapter13_shadowmap/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)

--- a/Chapter13_shadowmap/PMDActor.h
+++ b/Chapter13_shadowmap/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter14/Chapter14.vcxproj
+++ b/Chapter14/Chapter14.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -158,7 +158,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter14/Dx12Wrapper.cpp
+++ b/Chapter14/Dx12Wrapper.cpp
@@ -293,10 +293,12 @@ Dx12Wrapper::CreatePeraVertex() {
 						{{1,-1,0.1},{1,1}},
 						{{1,1,0.1},{1,0}} };
 
+	D3D12_HEAP_PROPERTIES heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	D3D12_RESOURCE_DESC resDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(pv));
 	auto result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(pv)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(_peraVB.ReleaseAndGetAddressOf()));
@@ -435,7 +437,8 @@ Dx12Wrapper::PreDrawToPera1() {
 		handle.InitOffsetted(baseH, offset);
 		offset += incSize;
 	}
-	_cmdList->OMSetRenderTargets(_countof(handles),handles, false, &_dsvHeap->GetCPUDescriptorHandleForHeapStart());
+	D3D12_CPU_DESCRIPTOR_HANDLE dsvHeapPointer = _dsvHeap->GetCPUDescriptorHandleForHeapStart();
+	_cmdList->OMSetRenderTargets(_countof(handles),handles, false, &dsvHeapPointer);
 	//クリアカラー		 R   G   B   A
 	float clsClr[4] = { 0.5,0.5,0.5,1.0 };
 	for (int i = 0; i < _countof(handles);++i) {
@@ -487,7 +490,8 @@ Dx12Wrapper::Clear() {
 void Dx12Wrapper::Barrier(ID3D12Resource* p,
 	D3D12_RESOURCE_STATES before,
 	D3D12_RESOURCE_STATES after){
-	_cmdList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(p, before, after, 0));
+	auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(p, before, after, 0);
+	_cmdList->ResourceBarrier(1, &barrier);
 }
 
 void 
@@ -973,10 +977,13 @@ Dx12Wrapper::CreatePrimitives() {
 	uint16_t indexes[]={ 0,1,2,1,3,2 };
 
 	//頂点バッファ作成
+	D3D12_HEAP_PROPERTIES heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	D3D12_RESOURCE_DESC resDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(plane));
 	ID3D12Resource* vbuff=nullptr;
-	auto result = _dev->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+	auto result = _dev->CreateCommittedResource(
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(plane)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&vbuff));
@@ -997,11 +1004,14 @@ Dx12Wrapper::CreatePrimitives() {
 	copy(begin(plane), end(plane), mappedVertex);
 	vbuff->Unmap(0, nullptr);
 
+	heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	resDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(indexes));
 	//インデックスバッファ作成
 	ID3D12Resource* ibuff = nullptr;
-	result = _dev->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+	result = _dev->CreateCommittedResource(
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(indexes)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&ibuff));
@@ -1094,11 +1104,14 @@ Dx12Wrapper::CreatePrimitives() {
 		++idx;
 	}
 
+	heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	resDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(cone));
 	//頂点バッファ作成
 	ID3D12Resource* coneVBuff = nullptr;
-	result = _dev->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+	result = _dev->CreateCommittedResource(
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(cone)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&coneVBuff));
@@ -1114,11 +1127,14 @@ Dx12Wrapper::CreatePrimitives() {
 
 	
 
+	heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	resDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(coneIdxes));
 	//インデックスバッファ作成
 	ID3D12Resource* coneIB = nullptr;
-	result = _dev->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+	result = _dev->CreateCommittedResource(
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(sizeof(coneIdxes)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&coneIB));
@@ -1632,14 +1648,15 @@ Dx12Wrapper::LoadPictureFromFile(wstring filepath, ComPtr<ID3D12Resource>& buff)
 			scratchImg);
 	}
 	else if (ext == L"dds") {
-		result = LoadFromDDSFile(filepath.c_str(),0,
+		result = LoadFromDDSFile(filepath.c_str(),
+			DDS_FLAGS_NONE,
 			&metadata,
 			scratchImg);
 		isDXT = true;
 	}
 	else {
 		result = LoadFromWICFile(filepath.c_str(),
-			0,
+			WIC_FLAGS_NONE,
 			&metadata,
 			scratchImg);
 	}

--- a/Chapter14/Helper.h
+++ b/Chapter14/Helper.h
@@ -2,6 +2,7 @@
 
 #include<d3d12.h>
 #include<vector>
+#include<string>
 
 class Helper
 {

--- a/Chapter14/PMDActor.cpp
+++ b/Chapter14/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)

--- a/Chapter14/PMDActor.h
+++ b/Chapter14/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter15/Chapter15.vcxproj
+++ b/Chapter15/Chapter15.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -158,7 +158,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter15/Helper.h
+++ b/Chapter15/Helper.h
@@ -2,6 +2,7 @@
 
 #include<d3d12.h>
 #include<vector>
+#include<string>
 
 class Helper
 {

--- a/Chapter15/PMDActor.cpp
+++ b/Chapter15/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)

--- a/Chapter15/PMDActor.h
+++ b/Chapter15/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter16/Chapter16.vcxproj
+++ b/Chapter16/Chapter16.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -172,7 +172,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter16/Helper.h
+++ b/Chapter16/Helper.h
@@ -2,6 +2,7 @@
 
 #include<d3d12.h>
 #include<vector>
+#include<string>
 
 class Helper
 {

--- a/Chapter16/PMDActor.cpp
+++ b/Chapter16/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)

--- a/Chapter16/PMDActor.h
+++ b/Chapter16/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter17/Chapter17.vcxproj
+++ b/Chapter17/Chapter17.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR);$(EFK_ROOT_DIR)\Effekseer;$(EFK_ROOT_DIR)\EffekseerRendererDX12</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>Effekseer.lib;EffekseerRendererDX12.lib;LLGI.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Chapter18/Chapter18.vcxproj
+++ b/Chapter18/Chapter18.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTK12_DIR)\Inc;$(DXTEX_DIR);$(EFK_ROOT_DIR)\Effekseer;$(EFK_ROOT_DIR)\EffekseerRendererDX12</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTK12_DIR)\Bin\Desktop_2017_Win10\x64\Debug;$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTK12_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>DirectXTK12.lib;Effekseer.lib;EffekseerRendererDX12.lib;LLGI.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Chapter3/main.cpp
+++ b/Chapter3/main.cpp
@@ -4,6 +4,7 @@
 #include<d3d12.h>
 #include<dxgi1_6.h>
 #include<vector>
+#include<string>
 #ifdef _DEBUG
 #include<iostream>
 #endif

--- a/Chapter4/main.cpp
+++ b/Chapter4/main.cpp
@@ -5,6 +5,7 @@
 #include<dxgi1_6.h>
 #include<DirectXMath.h>
 #include<vector>
+#include<string>
 
 #include<d3dcompiler.h>
 #ifdef _DEBUG

--- a/Chapter5/Chapter5.vcxproj
+++ b/Chapter5/Chapter5.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -113,10 +113,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -128,7 +130,7 @@
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicPS</EntryPointName>
-      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="BasicVertexShader.hlsl">
@@ -140,7 +142,7 @@
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Effect</ShaderType>
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
-      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
     </FxCompile>
   </ItemGroup>

--- a/Chapter5/main.cpp
+++ b/Chapter5/main.cpp
@@ -5,6 +5,7 @@
 #include<dxgi1_6.h>
 #include<DirectXMath.h>
 #include<vector>
+#include<string>
 
 #include<d3dcompiler.h>
 #include<DirectXTex.h>

--- a/Chapter5_CopyTexture/Chapter5_copytex.vcxproj
+++ b/Chapter5_CopyTexture/Chapter5_copytex.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -113,10 +113,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -127,6 +129,9 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">BasicPS</EntryPointName>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicPS</EntryPointName>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="BasicVertexShader.hlsl">
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">BasicVS</EntryPointName>

--- a/Chapter5_CopyTexture/main.cpp
+++ b/Chapter5_CopyTexture/main.cpp
@@ -5,6 +5,7 @@
 #include<dxgi1_6.h>
 #include<DirectXMath.h>
 #include<vector>
+#include<string>
 
 #include<d3dcompiler.h>
 #include<DirectXTex.h>

--- a/Chapter6/Chapter6.vcxproj
+++ b/Chapter6/Chapter6.vcxproj
@@ -86,7 +86,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
@@ -119,6 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Chapter7/Chapter7.vcxproj
+++ b/Chapter7/Chapter7.vcxproj
@@ -88,7 +88,7 @@
       <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -113,10 +113,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Chapter7/main.cpp
+++ b/Chapter7/main.cpp
@@ -291,12 +291,14 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 	unsigned int indicesNum;//インデックス数
 	fread(&indicesNum, sizeof(indicesNum), 1, fp);
+	auto heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	auto resDesc = CD3DX12_RESOURCE_DESC::Buffer(vertices.size() * sizeof(PMD_VERTEX));
 	//UPLOAD(確保は可能)
 	ID3D12Resource* vertBuff = nullptr;
 	result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(vertices.size() * sizeof(PMD_VERTEX)),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&vertBuff));
@@ -317,12 +319,14 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	fclose(fp);
 
 	ID3D12Resource* idxBuff = nullptr;
+	heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	resDesc = CD3DX12_RESOURCE_DESC::Buffer(indices.size() * sizeof(indices[0]));
 	//設定は、バッファのサイズ以外頂点バッファの設定を使いまわして
 	//OKだと思います。
 	result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer(indices.size()*sizeof(indices[0])),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&idxBuff));
@@ -552,11 +556,13 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		1.0f,//近い方
 		100.0f//遠い方
 	);
+	heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+	resDesc = CD3DX12_RESOURCE_DESC::Buffer((sizeof(MatricesData) + 0xff) & ~0xff);
 	ID3D12Resource* constBuff = nullptr;
 	result = _dev->CreateCommittedResource(
-		&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
-		&CD3DX12_RESOURCE_DESC::Buffer((sizeof(MatricesData) + 0xff)&~0xff),
+		&resDesc,
 		D3D12_RESOURCE_STATE_GENERIC_READ,
 		nullptr,
 		IID_PPV_ARGS(&constBuff)

--- a/Chapter8/Chapter8.vcxproj
+++ b/Chapter8/Chapter8.vcxproj
@@ -89,7 +89,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <FxCompile>
       <EntryPointName />

--- a/Chapter9_Refactored/Chapter9_Refactored.vcxproj
+++ b/Chapter9_Refactored/Chapter9_Refactored.vcxproj
@@ -89,7 +89,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -119,7 +119,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
     </Link>
     <FxCompile>
       <EntryPointName />

--- a/Chapter9_Refactored2/Chapter9_Refactored2.vcxproj
+++ b/Chapter9_Refactored2/Chapter9_Refactored2.vcxproj
@@ -86,7 +86,7 @@
       <SDLCheck>false</SDLCheck>
       <ConformanceMode>false</ConformanceMode>
       <AdditionalIncludeDirectories>$(DXTEX_DIR)\</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug</AdditionalLibraryDirectories>
@@ -115,7 +115,7 @@
       <SDLCheck>false</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(DXTEX_DIR)\</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
VS2019 でビルドエラーが出るようだったので、コンパイルが通るようにしてみました。
DirectX も C++14 もあまり詳しくない為、誤った修正している可能性があります。ご注意ください。

＜主な修正箇所＞
|エラー|エラー概要|修正概要|
|:--------:|:------------------|:------------------|
|C1083|include ファイルを開けません。`DirectXTex.h`:No such file or directory|DirectXTexのライブラリの参照先をVS2017→2019に変更|
|C2039| `unique_ptr`: `std` のメンバーではありません|`#include <memory>` を追加|
|C2102|`&` に左辺値がありません|一旦、変数に代入するよう対応|
|C2664|intからenum値への型変換エラーを修正|enum 値を設定するよう修正|
|C2665|`LookAtMatrix`: 2 オーバーロードのどれも、すべての引数の型を変換できませんでした|引数型に `const` を追加|
|C3861|`sort`: 識別子が見つかりませんでした|`#include <algorithm>` を追加|
|C4138|始まりのデリミターがない閉じのコメントデリミター (*/) が見つかりました|スペースを追加 `*//` → `* //` |
|LNK1104|ファイル `DirectXTex.lib` を開くことができません|DirectXTexのライブラリの参照先をVS2017→2019に変更|
|X3501|`BasicVS`: entrypoint not found|リリースビルド時の エントリ ポイント名に誤りがあった為 `BasicVS` → `PeraVS` に修正|
|X4502|invalid vs_5_0 output semantic `SV_TARGET`|リリースビルド時のシェーダの種類の指定に誤り。ピクセルシェーダー/頂点シェーダの指定が逆になっていた|