### PR TITLE
リリースビルド版の実行時に初期化に失敗する問題に対応

### DIFF
--- a/Chapter12/Dx12Wrapper.cpp
+++ b/Chapter12/Dx12Wrapper.cpp
@@ -901,6 +901,8 @@ Dx12Wrapper::CreateEffectBufferAndView() {
 	//_dev->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
 	//	D3D12_HEAP_FLAG_NONE,
 	//	);
+
+	return true;
 }
 
 bool

--- a/Chapter12/PMDActor.cpp
+++ b/Chapter12/PMDActor.cpp
@@ -836,6 +836,7 @@ PMDActor::CreateTransformBufferView() {
 	handle.ptr += _dx->Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 	dev->CreateConstantBufferView(&viewDesc, handle);
 
+	return true;
 }
 
 ComPtr<ID3D12DescriptorHeap>

--- a/Chapter13/Dx12Wrapper.cpp
+++ b/Chapter13/Dx12Wrapper.cpp
@@ -906,6 +906,8 @@ Dx12Wrapper::CreateEffectBufferAndView() {
 	//_dev->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
 	//	D3D12_HEAP_FLAG_NONE,
 	//	);
+
+	return true;
 }
 
 bool

--- a/Chapter13/PMDActor.cpp
+++ b/Chapter13/PMDActor.cpp
@@ -833,6 +833,7 @@ PMDActor::CreateTransformBufferView() {
 	handle.ptr += _dx->Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 	dev->CreateConstantBufferView(&viewDesc, handle);
 
+	return true;
 }
 
 ComPtr<ID3D12DescriptorHeap>


### PR DESCRIPTION
下記プロジェクトが初期化に失敗していた為、修正。
・Chapter12(MultiPass)
・Chapter13(SHADOW)

＜主な修正箇所＞
|エラー|エラー概要|修正概要|
|:--------:|:------------------|:------------------|
|C4715|'Dx12Wrapper::CreateEffectBufferAndView': 値を返さないコントロール パスがあります。|正常時に明示的に戻り値を返却するよう修正|