### PR TITLE
VS2019でのビルドをサポート（第17及び18章）

### DIFF
--- a/Chapter17/Application.cpp
+++ b/Chapter17/Application.cpp
@@ -11,19 +11,19 @@
 
 //----エフェクトに必要なものの基本--------------
 //エフェクトレンダラ
-EffekseerRenderer::Renderer* _efkRenderer=nullptr;
+EffekseerRenderer::RendererRef _efkRenderer=nullptr;
 //エフェクトマネジャ
-Effekseer::Manager* _efkManager=nullptr;
+Effekseer::ManagerRef _efkManager=nullptr;
 
 //----DX12やVulkan,metalなどのコマンドリスト系への対応のためのもの----
 //メモリプール(詳しくは分かってない)
-EffekseerRenderer::SingleFrameMemoryPool* _efkMemoryPool = nullptr;
+Effekseer::RefPtr<EffekseerRenderer::SingleFrameMemoryPool> _efkMemoryPool = nullptr;
 //コマンドリスト(DX12とかVulkanへの対応のため)
-EffekseerRenderer::CommandList* _efkCmdList = nullptr;
+Effekseer::RefPtr<EffekseerRenderer::CommandList> _efkCmdList = nullptr;
 
 //----エフェクト再生に必要なもの---------------
 //エフェクト本体(エフェクトファイルに対応)
-Effekseer::Effect* _effect=nullptr;
+Effekseer::EffectRef _effect=nullptr;
 // エフェクトハンドル(再生中のエフェクトに対応)
 Effekseer::Handle _efkHandle;
 
@@ -119,7 +119,7 @@ Application::Initialize() {
 		2, //バックバッファの数
 		bbFormats, //レンダーターゲットフォーマット
 		1, //レンダーターゲット数
-		false, //デプスありか？
+		DXGI_FORMAT_UNKNOWN, //デプスフォーマット
 		false, //反対デプスありか？
 		10000);//最大パーティクルの数
 
@@ -143,8 +143,8 @@ Application::Initialize() {
 	_efkManager->SetModelLoader(_efkRenderer->CreateModelLoader());
 
 	//DX12特有の処理
-	_efkMemoryPool = EffekseerRendererDX12::CreateSingleFrameMemoryPool(_efkRenderer);
-	_efkCmdList = EffekseerRendererDX12::CreateCommandList(_efkRenderer, _efkMemoryPool);
+	_efkMemoryPool = EffekseerRenderer::CreateSingleFrameMemoryPool(_efkRenderer->GetGraphicsDevice());
+	_efkCmdList = EffekseerRenderer::CreateCommandList(_efkRenderer->GetGraphicsDevice(), _efkMemoryPool);
 	_efkRenderer->SetCommandList(_efkCmdList);
 
 	SyncronizeEffekseerCamera();
@@ -379,7 +379,7 @@ Application::Run() {
 			POINT pnt;
 			GetCursorPos(&pnt);
 			ScreenToClient(_hwnd, &pnt);
-			_dx12->SetFocusPos(pnt.x, pnt.y);
+			_dx12->SetFocusPos((float)pnt.x, (float)pnt.y);
 		}
 
 		_dx12->CmdList()->SetDescriptorHeaps(1, heapImgui.GetAddressOf());

--- a/Chapter17/Chapter17.vcxproj
+++ b/Chapter17/Chapter17.vcxproj
@@ -86,9 +86,10 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(DXTEX_DIR);$(EFK_ROOT_DIR)\Effekseer;$(EFK_ROOT_DIR)\EffekseerRendererDX12</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\Effekseer\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>Effekseer.lib;EffekseerRendererDX12.lib;LLGI.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -114,12 +115,14 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DXTEX_DIR);$(EFK_ROOT_DIR)\Effekseer;$(EFK_ROOT_DIR)\EffekseerRendererDX12</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release;$(EFK_ROOT_DIR)\Release;$(EFK_ROOT_DIR)\Effekseer\Release;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Release;$(EFK_ROOT_DIR)\3RdParty\LLGI\src\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Effekseer.lib;EffekseerRendererDX12.lib;LLGI.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -172,7 +175,7 @@
       <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
-      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">BasicVS</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PeraVS</EntryPointName>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
     </FxCompile>

--- a/Chapter17/Helper.h
+++ b/Chapter17/Helper.h
@@ -2,6 +2,7 @@
 
 #include<d3d12.h>
 #include<vector>
+#include<string>
 
 class Helper
 {

--- a/Chapter17/PMDActor.cpp
+++ b/Chapter17/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)
@@ -816,6 +816,7 @@ PMDActor::CreateTransformBufferView() {
 	handle.ptr += _dx->Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 	dev->CreateConstantBufferView(&viewDesc, handle);
 
+	return true;
 }
 
 void 

--- a/Chapter17/PMDActor.h
+++ b/Chapter17/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Chapter18/Application.cpp
+++ b/Chapter18/Application.cpp
@@ -13,19 +13,19 @@
 
 //----エフェクトに必要なものの基本--------------
 //エフェクトレンダラ
-EffekseerRenderer::Renderer* _efkRenderer=nullptr;
+EffekseerRenderer::RendererRef _efkRenderer=nullptr;
 //エフェクトマネジャ
-Effekseer::Manager* _efkManager=nullptr;
+Effekseer::ManagerRef _efkManager=nullptr;
 
 //----DX12やVulkan,metalなどのコマンドリスト系への対応のためのもの----
 //メモリプール(詳しくは分かってない)
-EffekseerRenderer::SingleFrameMemoryPool* _efkMemoryPool = nullptr;
+Effekseer::RefPtr<EffekseerRenderer::SingleFrameMemoryPool> _efkMemoryPool = nullptr;
 //コマンドリスト(DX12とかVulkanへの対応のため)
-EffekseerRenderer::CommandList* _efkCmdList = nullptr;
+Effekseer::RefPtr<EffekseerRenderer::CommandList> _efkCmdList = nullptr;
 
 //----エフェクト再生に必要なもの---------------
 //エフェクト本体(エフェクトファイルに対応)
-Effekseer::Effect* _effect=nullptr;
+Effekseer::EffectRef _effect=nullptr;
 // エフェクトハンドル(再生中のエフェクトに対応)
 Effekseer::Handle _efkHandle;
 
@@ -147,7 +147,7 @@ Application::Initialize() {
 		2, //バックバッファの数
 		bbFormats, //レンダーターゲットフォーマット
 		1, //レンダーターゲット数
-		false, //デプスありか？
+		DXGI_FORMAT_UNKNOWN, //デプスフォーマット
 		false, //反対デプスありか？
 		2000);//最大パーティクルの数
 
@@ -171,8 +171,8 @@ Application::Initialize() {
 	_efkManager->SetModelLoader(_efkRenderer->CreateModelLoader());
 
 	//DX12特有の処理
-	_efkMemoryPool = EffekseerRendererDX12::CreateSingleFrameMemoryPool(_efkRenderer);
-	_efkCmdList = EffekseerRendererDX12::CreateCommandList(_efkRenderer, _efkMemoryPool);
+	_efkMemoryPool = EffekseerRenderer::CreateSingleFrameMemoryPool(_efkRenderer->GetGraphicsDevice());
+	_efkCmdList = EffekseerRenderer::CreateCommandList(_efkRenderer->GetGraphicsDevice(), _efkMemoryPool);
 	_efkRenderer->SetCommandList(_efkCmdList);
 
 	SyncronizeEffekseerCamera();
@@ -402,7 +402,7 @@ Application::Run() {
 			POINT pnt;
 			GetCursorPos(&pnt);
 			ScreenToClient(_hwnd, &pnt);
-			_dx12->SetFocusPos(pnt.x, pnt.y);
+			_dx12->SetFocusPos((float)pnt.x, (float)pnt.y);
 		}
 
 

--- a/Chapter18/Chapter18.vcxproj
+++ b/Chapter18/Chapter18.vcxproj
@@ -86,9 +86,10 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(DXTK12_DIR)\Inc;$(DXTEX_DIR);$(EFK_ROOT_DIR)\Effekseer;$(EFK_ROOT_DIR)\EffekseerRendererDX12</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(DXTK12_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(DXTEX_DIR)\Bin\Desktop_2017_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTK12_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Debug;$(EFK_ROOT_DIR)\Debug;$(EFK_ROOT_DIR)\Effekseer\Debug;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Debug;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>DirectXTK12.lib;Effekseer.lib;EffekseerRendererDX12.lib;LLGI.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -114,12 +115,14 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(DXTEX_DIR)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DXTK12_DIR)\Inc;$(DXTEX_DIR);$(EFK_ROOT_DIR)\Effekseer;$(EFK_ROOT_DIR)\EffekseerRendererDX12</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(DXTK12_DIR)\Bin\Desktop_2019_Win10\x64\Release;$(DXTEX_DIR)\Bin\Desktop_2019_Win10\x64\Release;$(EFK_ROOT_DIR)\Release;$(EFK_ROOT_DIR)\Effekseer\Release;$(EFK_ROOT_DIR)\EffekseerRendererDX12\Release;$(EFK_ROOT_DIR)\3rdParty\LLGI\src\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>DirectXTK12.lib;Effekseer.lib;EffekseerRendererDX12.lib;LLGI.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Chapter18/Helper.h
+++ b/Chapter18/Helper.h
@@ -2,6 +2,7 @@
 
 #include<d3d12.h>
 #include<vector>
+#include<string>
 
 class Helper
 {

--- a/Chapter18/PMDActor.cpp
+++ b/Chapter18/PMDActor.cpp
@@ -3,7 +3,7 @@
 #include<cassert>
 #include<DirectXMath.h>
 #include<string>
-
+#include<algorithm>
 
 #include<sstream>//文字列ストリーム用
 #include<iomanip>//文字列マニピュレータ用(n桁そろえとか0埋めとかに使う)
@@ -816,6 +816,7 @@ PMDActor::CreateTransformBufferView() {
 	handle.ptr += _dx->Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 	dev->CreateConstantBufferView(&viewDesc, handle);
 
+	return true;
 }
 
 void 

--- a/Chapter18/PMDActor.h
+++ b/Chapter18/PMDActor.h
@@ -8,6 +8,7 @@
 #include<wrl.h>
 #include<map>
 #include<unordered_map>
+#include<memory>
 
 using Microsoft::WRL::ComPtr;
 class Dx12Wrapper;

--- a/Dx12BookSamples.sln
+++ b/Dx12BookSamples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chapter04(Rendering Polygon)", "Chapter4\Chapter4.vcxproj", "{8482CF1B-AC98-4420-983C-89A9B0293ED5}"
 EndProject


### PR DESCRIPTION
17章、18章についてもVS2019でビルド通るよう修正しました。
依存関係にある下記ライブラリについてはマルチスレッドDLL「/MD」でビルド通ることを確認しました。
・DirectXTex
・DirectXTK12
・Effekseer
・EffekseerRendererDX12
・LLGI

それと、Dx12BookSamples.sln ファイルの形式についても 15（VS2017）→ 16（VS2019）に変更しました。
